### PR TITLE
🐞 fix: Convert slc for Tuple #6

### DIFF
--- a/som_anomaly_detector/kohonen_som.py
+++ b/som_anomaly_detector/kohonen_som.py
@@ -129,7 +129,7 @@ class KohonenSom(object):
         for i, shape_ind in enumerate(self.shape):
             slc = [slice(None)] * len(bmu_distance.shape)
             slc[i] = slice(shape_ind, 2 * shape_ind)
-            bmu_distance = bmu_distance[slc]
+            bmu_distance = bmu_distance[tuple(slc)]
 
         # Multiply by sigma to emulate a decreasing radius effect
         bmu_distance = sigma * bmu_distance


### PR DESCRIPTION
Upon running the code, I received the following error:

`Traceback (most recent call last): File "<string>", line 1, in <module> IndexError: only integers, slices (:), ellipsis (...), numpy.newaxis (None) and integer or boolean arrays are valid indices`

This error occurs in the file som_anomaly_detector\kohonen_som.py on line 132. To fix it, the following modification was necessary:

`bmu_distance = bmu_distance[tuple(slc)]`